### PR TITLE
fix: collision issue

### DIFF
--- a/contracts/tokenBridge/TokenBridge.sol
+++ b/contracts/tokenBridge/TokenBridge.sol
@@ -119,7 +119,7 @@ contract TokenBridge is ITokenBridge, PausableUpgradeable, Ownable2StepUpgradeab
     address _token,
     uint256 _amount,
     address _recipient
-  ) public payable nonZeroAddress(_token) nonZeroAmount(_amount) whenNotPaused {
+  ) public payable nonZeroAddress(_token) nonZeroAddress(_recipient) nonZeroAmount(_amount) whenNotPaused {
     address nativeMappingValue = nativeToBridgedToken[_token];
 
     if (nativeMappingValue == RESERVED_STATUS) {

--- a/contracts/tokenBridge/interfaces/ITokenBridge.sol
+++ b/contracts/tokenBridge/interfaces/ITokenBridge.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.19;
 interface ITokenBridge {
   event TokenReserved(address token);
   event CustomContractSet(address nativeToken, address customContract);
-  event BridgingInitiated(address sender, address recipient, address token, uint256 amount);
+  event BridgingInitiated(address sender, address recipient, address token, uint256 amount, bool _isNativeLayer);
   event BridgingFinalized(address nativeToken, address bridgedToken, uint256 amount, address recipient);
   event NewToken(address token);
   event NewTokenDeployed(address bridgedToken);
@@ -57,6 +57,7 @@ interface ITokenBridge {
     address _nativeToken,
     uint256 _amount,
     address _recipient,
+    bool _isNativeLayer,
     bytes calldata _tokenMetadata
   ) external;
 

--- a/test/tokenBridge/TokenBridge.ts
+++ b/test/tokenBridge/TokenBridge.ts
@@ -90,7 +90,7 @@ describe("TokenBridge", function () {
         encodedTokenMetadata,
       } = await loadFixture(deployContractsFixture);
       await expect(
-        l1TokenBridge.connect(user).completeBridging(L1DAI.address, 1, user.address, encodedTokenMetadata),
+        l1TokenBridge.connect(user).completeBridging(L1DAI.address, 1, user.address, true, encodedTokenMetadata),
       ).to.be.revertedWithCustomError(l1TokenBridge, "CallerIsNotMessageService");
     });
 
@@ -111,7 +111,7 @@ describe("TokenBridge", function () {
           l1TokenBridge.interface.encodeFunctionData(
             // calldata
             "completeBridging ",
-            [L1DAI.address, 1, user.address, encodedTokenMetadata],
+            [L1DAI.address, 1, user.address, true, encodedTokenMetadata],
           ),
         ),
       ).to.be.revertedWithCustomError(l1TokenBridge, "SenderNotAuthorized");
@@ -473,6 +473,17 @@ describe("TokenBridge", function () {
         l1TokenBridge,
         "NewToken",
       );
+    });
+
+    it("Should revert if recipient is set at 0 address", async function () {
+      const {
+        user,
+        tokens: { L1DAI },
+        l1TokenBridge,
+      } = await loadFixture(deployContractsFixture);
+      await expect(
+        l1TokenBridge.connect(user).bridgeToken(L1DAI.address, 1, ethers.constants.AddressZero),
+      ).to.revertedWithCustomError(l1TokenBridge, "ZeroAddressNotAllowed");
     });
   });
 


### PR DESCRIPTION
Revert in completeBridging if it is detected as native on other layer and current layer.
Here the funds from the attacker will stay locked on the source layer because we won't be minting bridgedTokens on target layer, it will also be impossible to bridge again from the source layer using the same native token making the bridge unusable for this token.