### PR TITLE
fix: collision issues by adding chainId as a key in the token mapping

### DIFF
--- a/contracts/tokenBridge/BridgedToken.sol
+++ b/contracts/tokenBridge/BridgedToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 import { ERC20PermitUpgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20PermitUpgradeable.sol";
 

--- a/contracts/tokenBridge/TokenBridge.sol
+++ b/contracts/tokenBridge/TokenBridge.sol
@@ -240,7 +240,7 @@ contract TokenBridge is
       bridgedToken = nativeMappingValue;
       if (nativeMappingValue == EMPTY) {
         // New token
-        bridgedToken = deployBridgedToken(_nativeToken, _tokenMetadata);
+        bridgedToken = deployBridgedToken(_nativeToken, _tokenMetadata, sourceChainId);
         bridgedToNativeToken[bridgedToken] = _nativeToken;
         nativeToBridgedToken[targetChainId][_nativeToken] = bridgedToken;
       }
@@ -319,11 +319,12 @@ contract TokenBridge is
    * @param _tokenMetadata The encoded metadata for the token.
    * @return The address of the newly deployed BridgedToken contract.
    */
-  function deployBridgedToken(address _nativeToken, bytes calldata _tokenMetadata) internal returns (address) {
-    bytes32 _salt;
-    assembly {
-      _salt := _nativeToken
-    }
+  function deployBridgedToken(
+    address _nativeToken,
+    bytes calldata _tokenMetadata,
+    uint256 chainId
+  ) internal returns (address) {
+    bytes32 _salt = keccak256(abi.encode(chainId, _nativeToken));
     BeaconProxy bridgedToken = new BeaconProxy{ salt: _salt }(tokenBeacon, "");
     address bridgedTokenAddress = address(bridgedToken);
 

--- a/contracts/tokenBridge/interfaces/ITokenBridge.sol
+++ b/contracts/tokenBridge/interfaces/ITokenBridge.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.19;
+pragma solidity 0.8.19;
 
 interface ITokenBridge {
   event TokenReserved(address token);
@@ -50,6 +50,7 @@ interface ITokenBridge {
    * @param _nativeToken The address of the token on its native chain.
    * @param _amount The amount of the token to be received.
    * @param _recipient The address that will receive the tokens.
+   * @param _chainId The source chainId or target chaindId for this token
    * @param _tokenMetadata Additional data used to deploy the bridged token if it
    *   doesn't exist already.
    */
@@ -57,6 +58,7 @@ interface ITokenBridge {
     address _nativeToken,
     uint256 _amount,
     address _recipient,
+    uint256 _chainId,
     bytes calldata _tokenMetadata
   ) external;
 

--- a/contracts/tokenBridge/mocks/MockTokenBridge.sol
+++ b/contracts/tokenBridge/mocks/MockTokenBridge.sol
@@ -5,6 +5,6 @@ import { TokenBridge } from "../TokenBridge.sol";
 
 contract MockTokenBridge is TokenBridge {
   function setNativeMappingValue(address token, address value) external {
-    nativeToBridgedToken[token] = value;
+    nativeToBridgedToken[1][token] = value;
   }
 }

--- a/contracts/tokenBridge/mocks/Reentrancy/MaliciousERC777.sol
+++ b/contracts/tokenBridge/mocks/Reentrancy/MaliciousERC777.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import { TokenBridge } from "../../TokenBridge.sol";
+import { ReentrancyContract } from "./ReentrancyContract.sol";
+
+contract MaliciousERC777 {
+  mapping(address => uint256) public balanceOf;
+  ReentrancyContract private reentrancyContract;
+
+  constructor(address _reentrancyContract) {
+    reentrancyContract = ReentrancyContract(_reentrancyContract);
+  }
+
+  function mint(address _to, uint256 _amount) external {
+    balanceOf[_to] += _amount;
+  }
+
+  function transferFrom(address _from, address _to, uint256 _amount) external {
+    reentrancyContract.beforeTokenTransfer();
+
+    balanceOf[_from] -= _amount;
+    balanceOf[_to] += _amount;
+  }
+
+  function name() external pure returns (string memory) {
+    return "Token";
+  }
+
+  function symbol() external pure returns (string memory) {
+    return "Token";
+  }
+
+  function decimals() external pure returns (uint8) {
+    return 18;
+  }
+}

--- a/contracts/tokenBridge/mocks/Reentrancy/ReentrancyContract.sol
+++ b/contracts/tokenBridge/mocks/Reentrancy/ReentrancyContract.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import { TokenBridge } from "../../TokenBridge.sol";
+
+contract ReentrancyContract {
+  // The Linea `TokenBridge` contract
+  TokenBridge private tokenBridge;
+
+  // A simple ERC777 token with transfer hooks for this PoC
+  address private token;
+
+  // Counts how often we re-entered the bridge from `beforeTokenTransfer` below.
+  uint256 private counter;
+
+  constructor(address _tokenBridge) {
+    counter = 0;
+    tokenBridge = TokenBridge(_tokenBridge);
+  }
+
+  function setToken(address _token) external {
+    token = _token;
+  }
+
+  function beforeTokenTransfer() external {
+    counter++;
+    if (counter == 5) {
+      // Stop the re-entrancy loop
+      return;
+    } else if (counter == 4) {
+      // The final re-entrancy. Send the full token amount.
+      tokenBridge.bridgeToken(token, 20, address(this));
+    } else {
+      // Keep the loop going with 1 wei.
+      tokenBridge.bridgeToken(token, 1, address(this));
+    }
+  }
+}

--- a/deployments.json
+++ b/deployments.json
@@ -4,8 +4,8 @@
     "TokenBridge": "0xb554949Cf593EBd306F6a03418Ee8396BdeE9441"
   },
   "hardhat": {
-    "l1TokenBeacon": "0x4C4a2f8c81640e47606d3fd77B353E87Ba015584",
-    "l2TokenBeacon": "0x21dF544947ba3E8b3c32561399E88B52Dc8b2823"
+    "l1TokenBeacon": "0x67d269191c92Caf3cD7723F116c85e6E9bf55933",
+    "l2TokenBeacon": "0xE6E340D132b5f46d1e472DebcD681B2aBc16e57E"
   },
   "l2": {
     "BridgedToken": "0x28315B48C7CBA7380Bdf4b80F4b8732f46031F6B",

--- a/scripts/tokenBridge/test/deployTokenBridges.ts
+++ b/scripts/tokenBridge/test/deployTokenBridges.ts
@@ -1,9 +1,11 @@
 import { ethers, upgrades } from "hardhat";
 
 import { deployBridgedTokenBeacon } from "./deployBridgedTokenBeacon";
+import { SupportedChainIds } from "../supportedNetworks";
 
 export async function deployTokenBridge(messageServiceAddress: string, verbose = false) {
   const [owner] = await ethers.getSigners();
+  const chainIds = [SupportedChainIds.GOERLI, SupportedChainIds.LINEA_TESTNET];
 
   // Deploy beacon for bridged tokens
   const tokenBeacons = await deployBridgedTokenBeacon(verbose);
@@ -15,6 +17,8 @@ export async function deployTokenBridge(messageServiceAddress: string, verbose =
     owner.address,
     messageServiceAddress,
     tokenBeacons.l1TokenBeacon.address,
+    chainIds[0],
+    chainIds[1],
     [], // Reseved Addresses
   ]);
   await l1TokenBridge.deployed();
@@ -26,6 +30,8 @@ export async function deployTokenBridge(messageServiceAddress: string, verbose =
     owner.address,
     messageServiceAddress,
     tokenBeacons.l2TokenBeacon.address,
+    chainIds[1],
+    chainIds[0],
     [], // Reseved Addresses
   ]);
   await l2TokenBridge.deployed();
@@ -44,7 +50,7 @@ export async function deployTokenBridge(messageServiceAddress: string, verbose =
     console.log("Deployment finished");
   }
 
-  return { l1TokenBridge, l2TokenBridge, ...tokenBeacons };
+  return { l1TokenBridge, l2TokenBridge, chainIds, ...tokenBeacons };
 }
 
 export async function deployTokenBridgeWithMockMessaging(verbose = false) {


### PR DESCRIPTION
This is what we think is a better version of the first fix we have made for the token address collision issue: https://github.com/Consensys/linea-contracts-fix/pull/1

The first fix would avoid stealing funds users but would still lock the deployer's funds making it impossible to support having 2 tokens of the same address being bridged at the same time.
With this solution we believe it will make the scenario viable and will work as expected the same as it would in any other scenario, meaning that for each token considered on both chain the bridge will create its counter part "bridgedToken" on the targeted layer.

- The main changes in the structure are here : https://github.com/Consensys/linea-contracts-fix/blob/c89367bb75417b261ffeb5a8d9c97158e9855743/contracts/tokenBridge/TokenBridge.sol#L48C1-L51C32
And here : https://github.com/Consensys/linea-contracts-fix/blob/c89367bb75417b261ffeb5a8d9c97158e9855743/contracts/tokenBridge/TokenBridge.sol#L44

- By introducing a second key in the `nativeToBridgedToken` we are creating a unique key composed of chainId+address that should avoid any collision issue.

PS: This PR has a lot of changes because it integrates the reentrancy fix + gas optimizations but you can mainly focus on the changes impacted by the 3 lines pointed above in the file TokenBridge.sol
Also I'm working on a unit test specific for this issue that will add later
